### PR TITLE
Add /profile slash command for StrafesNET stats

### DIFF
--- a/src/SlashCommands/Profile.lua
+++ b/src/SlashCommands/Profile.lua
@@ -146,35 +146,17 @@ local function Callback(Interaction, Command, Args)
 		CompletionCount = ReleasedCompletions .. '/' .. TotalReleasedMaps
 	end
 
-	-- WR count (paginate through all pages)
+	-- WR count (fetch all WRs for the game, filter by style)
 	local WRCount = 'N/A'
-	local WRTotal = 0
-	local WRPage = 0
-	local WRFetched = false
-	local WRDone = false
-	while not WRDone do
-		local WRHeaders, WRResponse = StrafesNET.GetWorldRecords(Id, nil, GameId, 0, StyleId, 100, WRPage)
-		if tonumber(WRHeaders.code) < 400 and WRResponse then
-			WRFetched = true
-			if WRResponse.pagination and WRResponse.pagination.total_items then
-				WRTotal = WRResponse.pagination.total_items
-				WRDone = true
-			elseif WRResponse.data then
-				WRTotal = WRTotal + #WRResponse.data
-				if #WRResponse.data < 100 then
-					WRDone = true
-				else
-					WRPage = WRPage + 1
-				end
-			else
-				WRDone = true
+	local Records, WRErr = StrafesNET.GetAllUserWorldRecords(Id, GameId, 0)
+	if Records then
+		local Count = 0
+		for _, Record in next, Records do
+			if Record.style_id == StyleId then
+				Count = Count + 1
 			end
-		else
-			WRDone = true
 		end
-	end
-	if WRFetched then
-		WRCount = tostring(WRTotal)
+		WRCount = tostring(Count)
 	end
 
 	local Embed = {


### PR DESCRIPTION
## Summary
- Adds `/profile game:<Bhop|Surf> style:<...>` with the same user lookup options as `/user` (username, user_id, member, or self via linked account)
- Embed shows: ID, Rank, Skill, Completions (released maps only, e.g. `47/312`), World Records, and moderation Status

## Details
- **Completion count**: filters to released maps (`Map.date < now`), same logic as `/calculate`
- **WR count**: fetches all user WRs via `GetAllUserWorldRecords`, filters by style client-side
- **Status**: reads `state_id` from `GET /user/{id}` — Normal / Whitelisted / Blacklisted / Pending / Not registered

## Test plan
- [ ] `/profile game:BHOP style:AUTOHOP` with no user arg (uses own linked account)
- [ ] `/profile game:SURF style:SIDEWAYS username:someuser`
- [ ] User not registered on StrafesNET (Status -> Not registered, rank/WR -> N/A)
- [ ] User with 0 completions (Completions -> 0/N, World Records -> 0)
